### PR TITLE
correctly support array-like member expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ function gen(node, fn) {
     return gen(node.callee, fn) + '(' + args.join(', ') + ')';
   } else if(node.type === "UnaryExpression") {
     return node.operator + gen(node.argument, fn);
-  } else if (node.type == 'MemberExpression') {
+  } else if (node.type == 'MemberExpression' && node.computed) {
+    return gen(node.object) + '[' + gen(node.property) + ']';
+  } else if (node.type == 'MemberExpression' && !node.computed) {
     return gen(node.object) + '.' + gen(node.property);
   } else if(node.type === "Literal") {
     return node.raw;

--- a/test.js
+++ b/test.js
@@ -22,4 +22,15 @@ describe('jsepgen', function() {
     assert.equal('Math.round(((Math.pow(Math.pow(A, B), C) + 5) + Math.pow(10, 5)))', expr);
   })
 
+  it('should correctly distinguish object and array property syntax', function() {
+    var expr = gen(jsep('arr[0]'))
+    assert.equal('arr[0]', expr)
+
+    expr = gen(jsep('obj["hi"]'))
+    assert.equal('obj["hi"]', expr)
+
+    expr = gen(jsep('obj.hi'))
+    assert.equal('obj.hi', expr)
+  })
+
 })


### PR DESCRIPTION
`gen('arr[0]')` was returning `'arr.0'`. Need to check if node is computed or not and use `.` or `[]` syntax accordingly.
